### PR TITLE
Remove Ölver from merchant list

### DIFF
--- a/merchant_names.csv
+++ b/merchant_names.csv
@@ -27,8 +27,6 @@ multi market ehf
 multi market
 olhusid grafarvogi
 olhusid
-olver sport og karaoke
-olver
 rain-skiptimynt
 rauda ljonid
 rauda ljonid-barthjon


### PR DESCRIPTION
Ölver no longer hosts slot machines.